### PR TITLE
Added argument support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
-project(rgcp VERSION 1.0.1 DESCRIPTION "RGCP networking middleware")
+project(rgcp VERSION 1.1.0 DESCRIPTION "RGCP networking middleware")
 include(GNUInstallDirs)
 
 set(TARGET_NAME rgcp_middleware)
@@ -11,6 +11,7 @@ set(EXECUTABLE_OUTPUT_PATH ${CMAKE_SOURCE_DIR}/bin)
 
 add_executable(${TARGET_NAME}
     src/details/logger.c
+    src/details/arg_parser.c
     src/details/api_packet.c
     src/details/rgcp_middleware_group.c
     src/client.c

--- a/src/details/arg_parser.c
+++ b/src/details/arg_parser.c
@@ -1,0 +1,132 @@
+#include "arg_parser.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <errno.h>
+#include <getopt.h>
+
+uint8_t g_bDisplayHelp = 0;
+uint8_t g_bPortIsSet = 0;
+uint8_t g_bHeartbeatTimeoutIsSet = 0;
+uint8_t g_bGroupTimeoutIsSet = 0;
+uint16_t g_middlewarePort = 0;
+time_t   g_heartbeatTimeout = 0;
+time_t   g_groupTimeout = 0;
+
+#define RGCP_MIDDLEWARE_HELP_MSG \
+"\
+usage: rgcp_middleware [options]\n\
+This middleware service allows RGCP sockets to interface with RGCP groups.\n\
+\n\
+Available options, with defaults in [ ]:\n\
+\t-p, --port\t\tSet the port on which the middleware listens for\n\
+\t\t\t\tconnections, ranges 1~65535. [8000]\n\
+\t-g, --group-timeout\tSet the time it takes for an inactive group to\n\
+\t\t\t\texpire in seconds. [60]\n\
+\t-b, --heartbeat-timeout\tSet the expected period for heartbeat messages received\n\
+\t\t\t\tfrom clients in seconds. [5]\n\
+\t-h, --help\t\tDisplay this help message.\n\
+\n\
+For contact info, issues, bug reports, feedback, etc., go to: www.github.com/nemjit001/rgcp-middleware\n\
+"
+
+static struct option g_longOptions[] = {
+    { "help",                   no_argument,        NULL, 0 },
+    { "port",                   required_argument,  NULL, 1 },
+    { "heartbeat-timeout",      required_argument,  NULL, 2 },
+    { "group-timeout",          required_argument,  NULL, 3 }
+};
+
+void display_help()
+{
+    printf("%s\n", RGCP_MIDDLEWARE_HELP_MSG);
+}
+
+int get_long_from_optarg(long* pOut)
+{
+    if (!pOut)
+        return -1;
+
+    errno = 0;
+    char* argStart = optarg;
+    char* argEnd = NULL;
+
+    *pOut = strtol(argStart, &argEnd, 10);
+
+    if (errno != 0 || argStart == argEnd)
+        return -1;
+
+    return 0;
+}
+
+int parse_middleware_arguments(int argc, char** argv)
+{
+    for(;;)
+    {
+        int longOptionIdx = 0;
+        int optRes = getopt_long(argc, argv, "hp:b:g:", g_longOptions, &longOptionIdx);
+
+        if (optRes < 0 || optRes == (int)('?'))
+            break;
+        
+        switch (optRes)
+        {
+        case 0:
+        case 'h':
+        {
+            // Early return for displaying help.
+            // Other arguments don't matter because the program exits once the help message has been displayed.
+
+            g_bDisplayHelp = 1;
+            display_help();
+            return 0;
+        }
+
+        case 1:
+        case 'p':
+        {
+            long setPort = -1;
+
+            if (get_long_from_optarg(&setPort) < 0)
+                return -1;
+            
+            if (setPort < 0 || setPort > 65535)
+                return -1;
+
+            g_middlewarePort = (uint16_t)setPort;
+            g_bPortIsSet = 1;
+            break;
+        }
+
+        case 2:
+        case 'b':
+        {
+            if (get_long_from_optarg(&g_heartbeatTimeout) < 0)
+                return -1;
+            
+            g_bHeartbeatTimeoutIsSet = 1;
+            break;
+        }
+
+        case 3:
+        case 'g':
+        {
+            if (get_long_from_optarg(&g_groupTimeout) < 0)
+                return -1;
+            
+            g_bGroupTimeoutIsSet = 1;
+            break;
+        }
+
+        default:
+            break;
+        }
+    }
+
+    if (optind < argc)
+        return -1;
+
+    return 0;
+}

--- a/src/details/arg_parser.h
+++ b/src/details/arg_parser.h
@@ -1,0 +1,17 @@
+#ifndef RGCP_MIDDLEWARE_ARG_PARSER
+#define RGCP_MIDDLEWARE_ARG_PARSER
+
+#include <stdint.h>
+#include <time.h>
+
+extern uint8_t g_bDisplayHelp;
+extern uint8_t g_bPortIsSet;
+extern uint8_t g_bHeartbeatTimeoutIsSet;
+extern uint8_t g_bGroupTimeoutIsSet;
+extern uint16_t g_middlewarePort;
+extern time_t   g_heartbeatTimeout;
+extern time_t   g_groupTimeout;
+
+int parse_middleware_arguments(int argc, char** argv);
+
+#endif

--- a/src/middleware.c
+++ b/src/middleware.c
@@ -11,6 +11,7 @@
 #include <rgcp/rgcp_group.h>
 
 #include "details/logger.h"
+#include "details/arg_parser.h"
 
 #define MIDDLEWARE_DEFAULT_PORT 8000
 #define MIDDLEWARE_DEFAULT_HEARTBEAT_TIMEOUT_SECONDS 5
@@ -744,10 +745,34 @@ int middleware_group_exists(struct middleware_state* pState, uint32_t groupHash)
     return 0;
 }
 
-int main(__attribute__((unused)) int argc, __attribute__((unused)) char** argv)
+int main(int argc, char** argv)
 {
     logger_init();
-    if (middleware_state_init(&g_middlewareState, MIDDLEWARE_DEFAULT_PORT, MIDDLEWARE_DEFAULT_HEARTBEAT_TIMEOUT_SECONDS, MIDDLEWARE_DEFAULT_GROUP_INACTIVE_TIMEOUT_SECONDS) < 0)
+
+    if (parse_middleware_arguments(argc, argv) < 0)
+    {
+        log_msg(LOG_LEVEL_ERROR, "Error parsing args\n");
+        return 0;
+    }
+
+    if (g_bDisplayHelp != 0)
+    {
+        log_msg(LOG_LEVEL_DEBUG, "Displayed Help Message\n");
+        return 0;
+    }
+
+    if (g_bPortIsSet == 0)
+        g_middlewarePort = MIDDLEWARE_DEFAULT_PORT;
+
+    if (g_bHeartbeatTimeoutIsSet == 0)
+        g_heartbeatTimeout = MIDDLEWARE_DEFAULT_HEARTBEAT_TIMEOUT_SECONDS;
+
+    if (g_bGroupTimeoutIsSet == 0)
+        g_groupTimeout = MIDDLEWARE_DEFAULT_GROUP_INACTIVE_TIMEOUT_SECONDS;
+
+    log_msg(LOG_LEVEL_DEBUG, "Initializing with params:\n\t(b: %ld, g: %ld, p: %d)\n", g_heartbeatTimeout, g_groupTimeout, g_middlewarePort);
+
+    if (middleware_state_init(&g_middlewareState, g_middlewarePort, g_heartbeatTimeout, g_groupTimeout) < 0)
     {
         perror("Failed to initialize Middleware");
         return -1;


### PR DESCRIPTION
- Bumped Minor version
- Added -p,--port argument
- Added -g,--group-timeout argument
- Added -b,--heartbeat-timeout argument
- Added -h,--help argument

Arguments allow for customizing middleware parameters on startup.
Help text explains how to use arguments.

Incremented Min version, 1.0.1 -> 1.1.0